### PR TITLE
Refactor Ubuntu 18.04 image | Reduce Size

### DIFF
--- a/ubuntu-18.04/Dockerfile
+++ b/ubuntu-18.04/Dockerfile
@@ -1,22 +1,22 @@
-FROM ubuntu:bionic
+FROM ubuntu:bionic as base
 MAINTAINER darkwizard242 <am900820@gmail.com>
 
-ENV dependencies "software-properties-common python3 python3-pip python3-setuptools python3-software-properties sudo apt-transport-https iputils-ping wget curl"
+ENV DEPENDENCIES "software-properties-common python3 python3-pip python3-setuptools python3-software-properties sudo apt-transport-https iputils-ping wget curl"
+
+ENV PIP_PKGS "ansible"
 
 # Install required dependencies
 RUN  DEBIAN_FRONTEND=non-interactive apt-get update -y \
-     && DEBIAN_FRONTEND=non-interactive apt-get upgrade -y \
-     && DEBIAN_FRONTEND=non-interactive apt-get install $dependencies -y \
+     && DEBIAN_FRONTEND=non-interactive apt-get --no-install-recommends -y upgrade \
+     && DEBIAN_FRONTEND=non-interactive apt-get install --no-install-recommends -y ${DEPENDENCIES} \
+     && python3 -m pip install --no-cache-dir -U pip wheel \
+     && python3 -m pip install --no-cache-dir -U ${PIP_PKGS} \
      && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb \
+     && for FILE in $(find /var/log -maxdepth 2 -type f); do echo "" > ${FILE}; done \
      && apt-get autoremove \
      && apt-get clean
 
-ENV pip_pkgs "ansible"
-#molecule flake8 ansible-lint molecule testinfra
-
-# Install required packages
-RUN python3 -m pip install -U pip wheel \
-    && python3 -m pip install -U $pip_pkgs
+FROM base
 
 # Initialize
 CMD ["/bin/bash"]


### PR DESCRIPTION
* Set as multi stage build
* Install pip packages with --no-cache-dir for size reduction.
* Find log files in /var/log and empty them for size reduction.